### PR TITLE
Merge neuromorphic-admin-app into the main job-manager app

### DIFF
--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -7,7 +7,8 @@ const { keycloak } = vi.hoisted(() => ({
 }));
 vi.mock("keycloak-js", () => ({ default: vi.fn(() => keycloak) }));
 
-import initAuth from "../src/auth";
+import initAuth, { checkPermissions } from "../src/auth";
+import type { Auth } from "../src/types";
 
 // initAuth does `keycloak.init(config).then(() => checkAuth(main))` and does not return the
 // promise, so tests flush the microtask/timer queue before asserting.
@@ -170,5 +171,41 @@ describe("verifyMessage (the framed-app message listener)", () => {
     listener({ data: "clb.authenticated", origin: "https://evil.example" });
 
     expect(keycloak.login).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkPermissions", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  test("marks the user as admin when they hold an admin role", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({ roles: { team: ["collab-neuromorphic-platform-admin-editor"] } })
+    );
+    const auth: Auth = { token: "t" };
+
+    await checkPermissions(auth);
+
+    expect(auth.isAdmin).toBe(true);
+  });
+
+  test("marks the user as non-admin when they hold no admin role", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ roles: { team: ["collab-something-else"] } }));
+    const auth: Auth = { token: "t" };
+
+    await checkPermissions(auth);
+
+    expect(auth.isAdmin).toBe(false);
+  });
+
+  test("sends the token in the Authorization header", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ roles: { team: [] } }));
+    const auth: Auth = { token: "my-token" };
+
+    await checkPermissions(auth);
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toMatchObject({ Authorization: "Bearer my-token" });
   });
 });

--- a/__tests__/components/admin/FilterButton.test.tsx
+++ b/__tests__/components/admin/FilterButton.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import FilterButton from "../../../src/components/admin/FilterButton";
+
+describe("FilterButton", () => {
+  it("renders the target label", () => {
+    render(<FilterButton target="accepted" current="under review" onClick={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "accepted" })).toBeTruthy();
+  });
+
+  it("calls onClick with its target when clicked", () => {
+    const onClick = vi.fn();
+    render(<FilterButton target="accepted" current="under review" onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "accepted" }));
+
+    expect(onClick).toHaveBeenCalledWith("accepted");
+  });
+});

--- a/__tests__/components/admin/QuotasTable.test.tsx
+++ b/__tests__/components/admin/QuotasTable.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import QuotasTable from "../../../src/components/admin/QuotasTable";
+import { makeQuota } from "../../fixtures";
+
+const noop = vi.fn();
+
+function renderTable(allowNew: boolean, quotas = [makeQuota()]) {
+  return render(
+    <QuotasTable
+      quotas={quotas}
+      newQuotaPlatform="SpiNNaker"
+      setNewQuotaPlatform={noop}
+      newQuotaLimit="0"
+      setNewQuotaLimit={noop}
+      allowNew={allowNew}
+    />
+  );
+}
+
+describe("QuotasTable", () => {
+  it("renders a row for each existing quota", () => {
+    renderTable(false, [makeQuota({ platform: "SpiNNaker", units: "core-hours" })]);
+    expect(screen.getByText("SpiNNaker")).toBeTruthy();
+    expect(screen.getByText("core-hours")).toBeTruthy();
+  });
+
+  it("renders a platform selector when new quotas are allowed", () => {
+    renderTable(true);
+    expect(screen.getByRole("combobox")).toBeTruthy();
+  });
+
+  it("renders nothing when there are no quotas and new quotas are not allowed", () => {
+    const { container } = renderTable(false, []);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/__tests__/components/admin/ResourceRequestDialog.test.tsx
+++ b/__tests__/components/admin/ResourceRequestDialog.test.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ResourceRequestDialog from "../../../src/components/admin/ResourceRequestDialog";
+import type { Auth } from "../../../src/types";
+import { makeResourceRequest } from "../../fixtures";
+
+const auth: Auth = { token: "t" };
+
+describe("ResourceRequestDialog", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  it("shows the review actions for an 'under review' request", () => {
+    const rr = makeResourceRequest({ status: "under review" });
+    render(<ResourceRequestDialog auth={auth} open onClose={vi.fn()} resourceRequest={rr} />);
+
+    expect(screen.getByRole("button", { name: "Reject" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Accept with Requested Quotas" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Accept but Set Different Quotas" })).toBeTruthy();
+  });
+
+  it("shows the 'Add quota' action for an accepted request", () => {
+    const rr = makeResourceRequest({ status: "accepted" });
+    render(<ResourceRequestDialog auth={auth} open onClose={vi.fn()} resourceRequest={rr} />);
+
+    expect(screen.getByRole("button", { name: "Add quota" })).toBeTruthy();
+  });
+
+  it("posts a quota and closes when a valid limit is added", async () => {
+    fetchMock.mockResponseOnce("", { status: 201 });
+    const onClose = vi.fn();
+    const rr = makeResourceRequest({ status: "accepted" });
+    render(<ResourceRequestDialog auth={auth} open onClose={onClose} resourceRequest={rr} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add quota" }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(fetchMock.mock.calls.length).toBe(1);
+  });
+
+  it("does not post a quota when the limit is not a number", () => {
+    const onClose = vi.fn();
+    const rr = makeResourceRequest({ status: "accepted" });
+    render(<ResourceRequestDialog auth={auth} open onClose={onClose} resourceRequest={rr} />);
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "abc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add quota" }));
+
+    expect(fetchMock.mock.calls.length).toBe(0);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate the resource request when editing the description", () => {
+    const rr = makeResourceRequest({ status: "under review", description: "original" });
+    render(<ResourceRequestDialog auth={auth} open onClose={vi.fn()} resourceRequest={rr} />);
+
+    fireEvent.change(screen.getByLabelText("Description"), { target: { value: "edited text" } });
+
+    expect(rr.description).toBe("original");
+  });
+});

--- a/__tests__/components/admin/ResourceRequestTable.test.tsx
+++ b/__tests__/components/admin/ResourceRequestTable.test.tsx
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ResourceRequestTable from "../../../src/components/admin/ResourceRequestTable";
+import { resourceRequests } from "../../fixtures";
+
+describe("ResourceRequestTable", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    fetchMock.mockResponse(JSON.stringify(resourceRequests));
+  });
+
+  it("shows requests with the default 'under review' status filter", async () => {
+    render(<ResourceRequestTable auth={{ token: "t" }} />);
+
+    expect(await screen.findByText("Under review project")).toBeTruthy();
+    expect(screen.queryByText("Accepted project")).toBeNull();
+    expect(screen.queryByText("Rejected project")).toBeNull();
+  });
+
+  it("switches the visible requests when another status filter is selected", async () => {
+    render(<ResourceRequestTable auth={{ token: "t" }} />);
+    await screen.findByText("Under review project");
+
+    fireEvent.click(screen.getByRole("button", { name: "accepted" }));
+
+    expect(await screen.findByText("Accepted project")).toBeTruthy();
+    expect(screen.queryByText("Under review project")).toBeNull();
+  });
+
+  it("filters the visible requests by the search field", async () => {
+    render(<ResourceRequestTable auth={{ token: "t" }} />);
+    await screen.findByText("Under review project");
+
+    fireEvent.change(screen.getByLabelText("Search"), { target: { value: "nomatch" } });
+
+    expect(screen.queryByText("Under review project")).toBeNull();
+  });
+});

--- a/__tests__/datastore.test.ts
+++ b/__tests__/datastore.test.ts
@@ -18,10 +18,23 @@ import {
   patchProject,
   createProject,
   deleteProject,
+  queryResourceRequests,
+  updateResourceRequest,
+  addQuota,
   resetCache,
 } from "../src/datastore";
 import { installMockServer } from "./mockServer";
-import { collabs, jobs, tags, comments, projects, serverAbout } from "./fixtures";
+import {
+  collabs,
+  jobs,
+  tags,
+  comments,
+  projects,
+  serverAbout,
+  makeResourceRequest,
+  resourceRequests,
+} from "./fixtures";
+import type { NewQuota } from "../src/types";
 
 const auth = { token: "test-token" };
 const testCollab = "neuromorphic-testing";
@@ -294,5 +307,81 @@ describe("deleteProject", () => {
       auth
     );
     expect(result).toBe("success");
+  });
+});
+
+// Admin section: cross-collab queries. Each test registers its own one-time fetch
+// response with mockResponseOnce, which takes precedence over the mock server default.
+describe("admin: resource requests", () => {
+  const lastRequestUrl = (): string => {
+    const calls = fetchMock.mock.calls;
+    return calls[calls.length - 1][0] as string;
+  };
+  const lastRequestInit = (): RequestInit => {
+    const calls = fetchMock.mock.calls;
+    return calls[calls.length - 1][1] as RequestInit;
+  };
+
+  describe("queryResourceRequests", () => {
+    test("requests all projects as admin and returns them", async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(resourceRequests));
+
+      const result = await queryResourceRequests(auth);
+
+      expect(result).toHaveLength(resourceRequests.length);
+      const url = lastRequestUrl();
+      expect(url).toContain("/projects/");
+      expect(url).toContain("as_admin=true");
+      expect(lastRequestInit().headers).toMatchObject({ Authorization: "Bearer test-token" });
+    });
+
+    test("throws when the server responds with an error", async () => {
+      fetchMock.mockResponseOnce("nope", { status: 500, statusText: "Server Error" });
+      await expect(queryResourceRequests(auth)).rejects.toThrow();
+    });
+  });
+
+  describe("updateResourceRequest", () => {
+    test("PUTs the update to the resource uri with as_admin", async () => {
+      fetchMock.mockResponseOnce("", { status: 200 });
+      const rr = makeResourceRequest({ resource_uri: "/projects/proj-1" });
+
+      await updateResourceRequest(
+        rr,
+        { title: rr.title, abstract: rr.abstract, owner: rr.owner, status: "accepted" },
+        auth
+      );
+
+      const url = lastRequestUrl();
+      expect(url).toContain("/projects/proj-1");
+      expect(url).toContain("as_admin=true");
+      const init = lastRequestInit();
+      expect(init.method).toBe("PUT");
+      expect(JSON.parse(init.body as string)).toMatchObject({ status: "accepted" });
+    });
+  });
+
+  describe("addQuota", () => {
+    test("POSTs the new quota to the quotas endpoint", async () => {
+      fetchMock.mockResponseOnce("", { status: 201 });
+      const rr = makeResourceRequest({ resource_uri: "/projects/proj-2" });
+      const newQuota: NewQuota = { platform: "SpiNNaker", limit: 5000, units: "core-hours" };
+
+      await addQuota(rr, newQuota, auth);
+
+      const url = lastRequestUrl();
+      expect(url).toContain("/projects/proj-2/quotas/");
+      const init = lastRequestInit();
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual(newQuota);
+    });
+
+    test("throws if the server does not return 201", async () => {
+      fetchMock.mockResponseOnce("", { status: 200 });
+      const rr = makeResourceRequest();
+      await expect(
+        addQuota(rr, { platform: "Demo", limit: 1, units: "hours" }, auth)
+      ).rejects.toThrow();
+    });
   });
 });

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -1,7 +1,7 @@
 // Mock data shaped to match the job-queue-api Pydantic models
 // (see job-queue-api/api/simqueue/data_models.py).
 
-import type { Comment, Job, Project, ServerAbout } from "../src/types";
+import type { Comment, Job, Project, Quota, ServerAbout } from "../src/types";
 
 // GET /collabs/ has response_model=list[str] — a plain list of collab ids
 const collabs: string[] = ["neuromorphic-testing", "cortical-models", "spiking-benchmarks"];
@@ -241,4 +241,61 @@ const serverAbout: ServerAbout = {
   links: { documentation: "/docs" },
 };
 
-export { collabs, jobs, tags, logs, comments, projects, serverAbout };
+// Factories and sample data for the admin section, where projects are presented as
+// "resource requests" across all collabs.
+export function makeQuota(overrides: Partial<Quota> = {}): Quota {
+  return {
+    limit: 1000,
+    usage: 100,
+    platform: "SpiNNaker",
+    units: "core-hours",
+    project: "proj-1",
+    resource_uri: "/projects/proj-1/quotas/q1",
+    ...overrides,
+  };
+}
+
+export function makeResourceRequest(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "proj-1",
+    collab: "collab-1",
+    title: "A test project",
+    status: "under review",
+    abstract: "An abstract describing the project.",
+    description: "A longer description.",
+    owner: "alice@example.com",
+    quotas: [],
+    resource_uri: "/projects/proj-1",
+    submission_date: "2026-01-01",
+    decision_date: null,
+    ...overrides,
+  };
+}
+
+const resourceRequests: Project[] = [
+  makeResourceRequest({
+    title: "Under review project",
+    status: "under review",
+    owner: "alice@example.com",
+    resource_uri: "/projects/proj-1",
+    submission_date: "2026-02-01",
+  }),
+  makeResourceRequest({
+    title: "Accepted project",
+    status: "accepted",
+    owner: "bob@example.com",
+    resource_uri: "/projects/proj-2",
+    submission_date: "2026-01-15",
+    decision_date: "2026-01-16",
+    quotas: [makeQuota({ project: "proj-2", resource_uri: "/projects/proj-2/quotas/q1" })],
+  }),
+  makeResourceRequest({
+    title: "Rejected project",
+    status: "rejected",
+    owner: "carol@example.com",
+    resource_uri: "/projects/proj-3",
+    submission_date: "2026-01-10",
+  }),
+];
+
+export { collabs, jobs, tags, logs, comments, projects, serverAbout, resourceRequests };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,10 +1,17 @@
 import Keycloak from "keycloak-js";
 import type { KeycloakInitOptions } from "keycloak-js";
 
-import { authServer, authClientId } from "./globals";
+import { authServer, authClientId, authScopes, adminRoles, userInfoUrl } from "./globals";
 import type { Auth } from "./types";
 
 type Main = (auth: Auth) => void;
+
+// Shape of the parts of the EBRAINS userinfo response we rely on.
+interface UserInfo {
+  roles: {
+    team: string[];
+  };
+}
 
 const keycloak = new Keycloak({
   url: `${authServer}/auth`,
@@ -62,7 +69,7 @@ function checkAuth(main: Main) {
     console.log("This is a standalone app...");
     if (isAnonymous) {
       console.log("...which is not authenticated, starting login...");
-      return keycloak.login();
+      return keycloak.login({ scope: authScopes });
     }
     if (isAuthenticated) {
       console.log("...which is authenticated, starting app with authentication");
@@ -91,7 +98,7 @@ function checkAuth(main: Main) {
     console.log("This is a delegate tab...");
     if (isAnonymous) {
       console.log("...which is not authenticated, starting login...");
-      return keycloak.login();
+      return keycloak.login({ scope: authScopes });
     }
     if (isAuthenticated) {
       console.log("...which is authenticated, warn parent and close...");
@@ -115,5 +122,21 @@ function verifyMessage(event: MessageEvent) {
   if (messageOrigin !== myAppOrigin) return;
 
   // Login otherwise
-  return keycloak.login();
+  return keycloak.login({ scope: authScopes });
+}
+
+// Determine whether the authenticated user is a platform administrator by inspecting
+// their EBRAINS team roles, and record the result on the auth object.
+export function checkPermissions(auth: Auth): Promise<void> {
+  const config: RequestInit = {
+    headers: {
+      Authorization: "Bearer " + auth.token,
+    },
+  };
+  return fetch(userInfoUrl, config)
+    .then((response) => response.json())
+    .then((userInfo: UserInfo) => {
+      auth.isAdmin = adminRoles.some((role) => userInfo.roles.team.includes(role));
+      console.log(auth.isAdmin ? "User is an administrator" : "User is not an administrator");
+    });
 }

--- a/src/components/admin/FilterButton.tsx
+++ b/src/components/admin/FilterButton.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@mui/material";
+
+interface FilterButtonProps {
+  target: string;
+  current: string;
+  onClick: (value: string) => void;
+}
+
+function FilterButton(props: FilterButtonProps) {
+  const { target, current, onClick } = props;
+
+  return (
+    <Button
+      variant={current === target ? "contained" : "outlined"}
+      color={current === target ? "primary" : "inherit"}
+      onClick={() => onClick(target)}
+    >
+      {target}
+    </Button>
+  );
+}
+
+export default FilterButton;

--- a/src/components/admin/QuotasTable.tsx
+++ b/src/components/admin/QuotasTable.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import type { ChangeEvent } from "react";
+import {
+  MenuItem,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { SelectChangeEvent } from "@mui/material/Select";
+
+import type { Quota } from "../../types";
+import { defaultQuotaSizes, platformUnits } from "../../globals";
+
+interface QuotasTableProps {
+  quotas: Quota[];
+  newQuotaPlatform: string;
+  setNewQuotaPlatform: (value: string) => void;
+  newQuotaLimit: string;
+  setNewQuotaLimit: (value: string) => void;
+  allowNew: boolean;
+}
+
+function QuotasTable(props: QuotasTableProps) {
+  const { quotas, newQuotaPlatform, setNewQuotaPlatform, newQuotaLimit, setNewQuotaLimit } = props;
+  const [nonDefaultQuota, setNonDefaultQuota] = useState(false);
+
+  const isValidNumber = (value: string) => {
+    return !isNaN(Number(value));
+  };
+
+  let newQuotaForm = <></>;
+  if (props.allowNew) {
+    newQuotaForm = (
+      <TableRow key="new quota">
+        <TableCell>
+          <Select
+            size="small"
+            label="Platform"
+            value={newQuotaPlatform}
+            onChange={(event: SelectChangeEvent) => {
+              setNewQuotaPlatform(event.target.value);
+            }}
+          >
+            <MenuItem value="SpiNNaker">SpiNNaker</MenuItem>
+            <MenuItem value="BrainScaleS">BrainScaleS</MenuItem>
+            <MenuItem value="BrainScaleS-2">BrainScaleS-2</MenuItem>
+            <MenuItem value="Spikey">Spikey</MenuItem>
+            <MenuItem value="Demo">Demo</MenuItem>
+          </Select>
+        </TableCell>
+        <TableCell>
+          <TextField
+            size="small"
+            value={nonDefaultQuota ? newQuotaLimit : defaultQuotaSizes[newQuotaPlatform]}
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              setNonDefaultQuota(true);
+              setNewQuotaLimit(event.target.value);
+            }}
+            error={!isValidNumber(newQuotaLimit)}
+            helperText={isValidNumber(newQuotaLimit) ? "" : "Enter a number"}
+          />
+        </TableCell>
+        <TableCell>0</TableCell>
+        <TableCell>{platformUnits[newQuotaPlatform]}</TableCell>
+      </TableRow>
+    );
+  }
+  if (quotas.length > 0 || props.allowNew) {
+    return (
+      <>
+        <Typography variant="subtitle1">Quotas</Typography>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Platform</TableCell>
+              <TableCell>Limit</TableCell>
+              <TableCell>Usage</TableCell>
+              <TableCell>Units</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {quotas.map((quota) => (
+              <TableRow key={quota.resource_uri}>
+                <TableCell>{quota.platform}</TableCell>
+                <TableCell>{quota.limit}</TableCell>
+                <TableCell>{quota.usage}</TableCell>
+                <TableCell>{quota.units}</TableCell>
+              </TableRow>
+            ))}
+            {newQuotaForm}
+          </TableBody>
+        </Table>
+      </>
+    );
+  } else {
+    return null;
+  }
+}
+
+export default QuotasTable;

--- a/src/components/admin/ResourceRequestDialog.tsx
+++ b/src/components/admin/ResourceRequestDialog.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+import QuotasTable from "./QuotasTable";
+import { addQuota, updateResourceRequest } from "../../datastore";
+import { platformUnits } from "../../globals";
+import type { Auth, NewQuota, Project } from "../../types";
+
+interface RRDialogProps {
+  auth: Auth;
+  open: boolean;
+  resourceRequest: Project | undefined;
+  onClose: () => void;
+}
+
+const chipColours: Record<string, string> = {
+  accepted: "#99cc33",
+  "under review": "#99cc33",
+  "in preparation": "#ffcc00",
+  rejected: "#ff9966",
+};
+
+function isValidNumber(value: string): boolean {
+  return value.trim() !== "" && !isNaN(Number(value));
+}
+
+interface AcceptedRequestActionsProps {
+  onClose: () => void;
+  onAddQuota: () => void;
+}
+
+interface UnderReviewRequestActionsProps {
+  onClose: () => void;
+  onAcceptRequest: () => void;
+  onRejectRequest: () => void;
+  onUpdateRequest: () => void;
+}
+
+function AcceptedRequestActions(props: AcceptedRequestActionsProps) {
+  return (
+    <>
+      <Button variant="contained" color="secondary" onClick={props.onClose}>
+        Cancel
+      </Button>
+      <Button variant="contained" onClick={props.onAddQuota}>
+        Add quota
+      </Button>
+    </>
+  );
+}
+
+function UnderReviewRequestActions(props: UnderReviewRequestActionsProps) {
+  return (
+    <>
+      <Button variant="contained" color="secondary" onClick={props.onClose}>
+        Cancel
+      </Button>
+      <Button variant="contained" onClick={props.onRejectRequest}>
+        Reject
+      </Button>
+      <Button variant="contained" onClick={props.onAcceptRequest}>
+        Accept with Requested Quotas
+      </Button>
+      <Button variant="contained" onClick={props.onUpdateRequest}>
+        Accept but Set Different Quotas
+      </Button>
+    </>
+  );
+}
+
+function DefaultActions({ onClose }: { onClose: () => void }) {
+  return (
+    <Button variant="contained" color="secondary" onClick={onClose}>
+      Cancel
+    </Button>
+  );
+}
+
+function ResourceRequestDialog(props: RRDialogProps) {
+  const { auth, onClose, resourceRequest, open } = props;
+  const [newQuotaPlatform, setNewQuotaPlatform] = useState("SpiNNaker");
+  const [newQuotaLimit, setNewQuotaLimit] = useState("0");
+  const [description, setDescription] = useState("");
+
+  // Seed the editable description from the current request whenever it changes,
+  // rather than mutating the prop during render.
+  useEffect(() => {
+    setDescription(resourceRequest?.description ?? "");
+  }, [resourceRequest]);
+
+  if (!resourceRequest) {
+    return null;
+  }
+
+  const handleAddQuota = () => {
+    if (!isValidNumber(newQuotaLimit)) {
+      return;
+    }
+    const newQuota: NewQuota = {
+      platform: newQuotaPlatform,
+      limit: Number(newQuotaLimit),
+      units: platformUnits[newQuotaPlatform] || "",
+    };
+    addQuota(resourceRequest, newQuota, auth)
+      .then(onClose)
+      .catch((err) => console.error(err));
+  };
+
+  const update = (status: string, newDescription?: string) => {
+    updateResourceRequest(
+      resourceRequest,
+      {
+        title: resourceRequest.title,
+        abstract: resourceRequest.abstract,
+        owner: resourceRequest.owner,
+        status,
+        ...(newDescription !== undefined ? { description: newDescription } : {}),
+      },
+      auth
+    )
+      .then(onClose)
+      .catch((err) => console.error(err));
+  };
+
+  const handleUpdateRequest = () => update("accepted", description);
+  const handleAcceptRequest = () => update("accepted");
+  const handleRejectRequest = () => update("rejected");
+
+  let actions = <DefaultActions onClose={onClose} />;
+  let dateInformation = <></>;
+  switch (resourceRequest.status) {
+    case "accepted":
+      actions = <AcceptedRequestActions onClose={onClose} onAddQuota={handleAddQuota} />;
+      dateInformation = (
+        <Typography variant="caption">
+          <b>Submitted</b>: {resourceRequest.submission_date}&nbsp;
+          <b>Accepted</b>: {resourceRequest.decision_date}
+        </Typography>
+      );
+      break;
+    case "under review":
+      actions = (
+        <UnderReviewRequestActions
+          onClose={onClose}
+          onAcceptRequest={handleAcceptRequest}
+          onRejectRequest={handleRejectRequest}
+          onUpdateRequest={handleUpdateRequest}
+        />
+      );
+      dateInformation = (
+        <Typography variant="caption" component="div">
+          <b>Submitted</b>: {resourceRequest.submission_date}
+          <TextField
+            fullWidth
+            multiline
+            size="small"
+            label="Description"
+            sx={{ mt: 1 }}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+          />
+        </Typography>
+      );
+      break;
+  }
+
+  return (
+    <Dialog onClose={onClose} open={open} fullWidth maxWidth="lg">
+      <DialogTitle>
+        <Chip
+          label={resourceRequest.status}
+          size="small"
+          sx={{ backgroundColor: chipColours[resourceRequest.status] }}
+        />
+        &nbsp;{resourceRequest.title}
+        <br />
+        {dateInformation}
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" sx={{ marginBottom: 1 }}>
+          {resourceRequest.abstract}
+        </Typography>
+        <Typography variant="caption" sx={{ marginBottom: 2 }}>
+          {resourceRequest.description}
+        </Typography>
+        <QuotasTable
+          quotas={resourceRequest.quotas}
+          newQuotaPlatform={newQuotaPlatform}
+          setNewQuotaPlatform={setNewQuotaPlatform}
+          newQuotaLimit={newQuotaLimit}
+          setNewQuotaLimit={setNewQuotaLimit}
+          allowNew={resourceRequest.status === "accepted"}
+        />
+      </DialogContent>
+      <DialogActions>{actions}</DialogActions>
+    </Dialog>
+  );
+}
+
+export default ResourceRequestDialog;

--- a/src/components/admin/ResourceRequestTable.tsx
+++ b/src/components/admin/ResourceRequestTable.tsx
@@ -1,0 +1,214 @@
+import { useState, useEffect, useCallback } from "react";
+import type { ChangeEvent } from "react";
+import {
+  Box,
+  ButtonGroup,
+  CircularProgress,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Paper,
+  Typography,
+} from "@mui/material";
+
+import FilterButton from "./FilterButton";
+import ResourceRequestDialog from "./ResourceRequestDialog";
+import { queryResourceRequests } from "../../datastore";
+import type { Auth, Quota, Project } from "../../types";
+
+interface Counter {
+  [key: string]: number;
+}
+
+interface Dict {
+  [key: string]: string;
+}
+
+function sortById(a: Project, b: Project) {
+  /* Newer requests should be at the start of the list */
+  if (a.submission_date) {
+    if (b.submission_date) {
+      if (a.submission_date > b.submission_date) {
+        return -1;
+      } else {
+        return 1;
+      }
+    } else {
+      return -1;
+    }
+  } else {
+    if (b.submission_date) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+}
+
+function QuotaSummary({ quotas }: { quotas: Quota[] }) {
+  /* Where we have multiple quotas for the same platform, sum up the usage and limits,
+     so we have at most one line per platform. */
+  const summedUsage: Counter = {};
+  const summedLimits: Counter = {};
+  const units: Dict = {};
+
+  for (const quota of quotas) {
+    if (quota.platform in summedUsage) {
+      summedUsage[quota.platform] += quota.usage;
+      summedLimits[quota.platform] += quota.limit;
+      // todo: check units match
+    } else {
+      summedUsage[quota.platform] = quota.usage;
+      summedLimits[quota.platform] = quota.limit;
+      units[quota.platform] = quota.units;
+    }
+  }
+  const percentUsed: Counter = {};
+  for (const platform in summedUsage) {
+    percentUsed[platform] = Math.floor((100 * summedUsage[platform]) / summedLimits[platform]);
+  }
+
+  const getColour = (usage: number) => {
+    if (usage < 50) {
+      return "green";
+    } else if (usage >= 100) {
+      return "red";
+    } else {
+      return "orange";
+    }
+  };
+
+  return (
+    <div>
+      {Object.keys(summedUsage).map((platform) => (
+        <Typography variant="body2" key={platform} sx={{ color: getColour(percentUsed[platform]) }}>
+          {`${platform}: ${percentUsed[platform]}%`}
+          <br />
+        </Typography>
+      ))}
+    </div>
+  );
+}
+
+function ResourceRequestTable({ auth }: { auth: Auth }) {
+  const [resourceRequests, setResourceRequests] = useState<Project[]>([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [currentResourceRequest, setCurrentResourceRequest] = useState(0);
+  const [statusFilter, setStatusFilter] = useState("under review");
+  const [searchInput, setSearchInput] = useState("");
+
+  const loadData = useCallback(
+    (signal?: AbortSignal) => {
+      queryResourceRequests(auth, signal)
+        .then((data) => {
+          setResourceRequests(data.sort(sortById));
+        })
+        .catch((err) => {
+          if (err.name !== "AbortError") {
+            console.error(err);
+          }
+        });
+    },
+    [auth]
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    loadData(controller.signal);
+    return () => controller.abort();
+  }, [loadData]);
+
+  const handleRowClick = (rowIndex: number) => {
+    setCurrentResourceRequest(rowIndex);
+    setDialogOpen(true);
+  };
+
+  const handleClose = async () => {
+    setDialogOpen(false);
+    loadData();
+  };
+
+  const filterResourceRequests = (rr: Project) => {
+    let include = rr.status === statusFilter;
+    if (include && searchInput) {
+      include =
+        rr.title.toLowerCase().includes(searchInput) ||
+        rr.abstract.toLowerCase().includes(searchInput) ||
+        rr.owner.includes(searchInput);
+    }
+    return include;
+  };
+
+  if (resourceRequests.length === 0) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <Stack direction="row" spacing={2}>
+        <ButtonGroup sx={{ paddingBottom: 3 }}>
+          <FilterButton target="accepted" current={statusFilter} onClick={setStatusFilter} />
+          <FilterButton target="under review" current={statusFilter} onClick={setStatusFilter} />
+          <FilterButton target="in preparation" current={statusFilter} onClick={setStatusFilter} />
+          <FilterButton target="rejected" current={statusFilter} onClick={setStatusFilter} />
+        </ButtonGroup>
+        <TextField
+          id="searchField"
+          label="Search"
+          variant="outlined"
+          size="small"
+          sx={{ width: "50%" }}
+          value={searchInput}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            setSearchInput(event.target.value.toLowerCase());
+          }}
+        />
+      </Stack>
+
+      <TableContainer component={Paper} sx={{ marginBottom: 5 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Title</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Abstract</TableCell>
+              <TableCell>Owner</TableCell>
+              <TableCell>Quotas</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {resourceRequests.filter(filterResourceRequests).map((rr, index) => (
+              <TableRow key={rr.resource_uri} onClick={() => handleRowClick(index)}>
+                <TableCell>{rr.title}</TableCell>
+                <TableCell>{rr.status}</TableCell>
+                <TableCell>{rr.abstract}</TableCell>
+                <TableCell>{rr.owner}</TableCell>
+                <TableCell>
+                  <QuotaSummary quotas={rr.quotas} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <ResourceRequestDialog
+        open={dialogOpen}
+        onClose={handleClose}
+        resourceRequest={resourceRequests.filter(filterResourceRequests)[currentResourceRequest]}
+        auth={auth}
+      />
+    </>
+  );
+}
+
+export default ResourceRequestTable;

--- a/src/components/general/Toolbar.tsx
+++ b/src/components/general/Toolbar.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 
-import { RequestedCollabContext } from "../../context";
+import { AuthContext, RequestedCollabContext } from "../../context";
 
 function renderButtons(page: string, collab?: string): ReactNode {
   switch (page) {
@@ -139,6 +139,7 @@ interface ToolbarProps {
 
 function Toolbar(props: ToolbarProps) {
   const requestedCollabId = useContext(RequestedCollabContext);
+  const auth = useContext(AuthContext);
 
   return (
     <Fragment>
@@ -160,6 +161,17 @@ function Toolbar(props: ToolbarProps) {
           >
             EBRAINS Neuromorphic Computing Service: Job Manager
           </Typography>
+          {auth?.isAdmin && props.page !== "admin" && (
+            <Button
+              color="inherit"
+              variant="outlined"
+              component={RouterLink}
+              to="/admin"
+              sx={{ mr: 1 }}
+            >
+              Admin
+            </Button>
+          )}
           {renderButtons(props.page, props.collab)}
         </MUIToolbar>
       </AppBar>

--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -1,6 +1,6 @@
 import { jobQueueServer } from "./globals";
 import { isAlmostEmpty, jobIsIncomplete } from "./utils";
-import type { Auth, Comment, Job, Project, ServerAbout } from "./types";
+import type { Auth, Comment, Job, NewQuota, Project, ProjectUpdate, ServerAbout } from "./types";
 
 interface Cache {
   about: ServerAbout | null;
@@ -386,6 +386,50 @@ function resetCache() {
   };
 }
 
+// Admin section: cross-collab queries that bypass the per-collab cache.
+
+// Fetch every project across all collabs (admin view).
+async function queryResourceRequests(auth: Auth, signal?: AbortSignal): Promise<Project[]> {
+  const url = jobQueueServer + "/projects/?size=10000&as_admin=true";
+  const config = getRequestConfig(auth);
+  if (signal) {
+    config.signal = signal;
+  }
+  const response = await fetch(url, config);
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+  return response.json();
+}
+
+// Update a project's status (and optionally its description) as an admin.
+async function updateResourceRequest(
+  project: Project,
+  update: ProjectUpdate,
+  auth: Auth
+): Promise<void> {
+  const url = `${jobQueueServer}${project.resource_uri}?as_admin=true`;
+  const config = getRequestConfig(auth);
+  config.method = "PUT";
+  config.body = JSON.stringify(update);
+  const response = await fetch(url, config);
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+}
+
+// Add a new quota to a project.
+async function addQuota(project: Project, newQuota: NewQuota, auth: Auth): Promise<void> {
+  const url = `${jobQueueServer}${project.resource_uri}/quotas/`;
+  const config = getRequestConfig(auth);
+  config.method = "POST";
+  config.body = JSON.stringify(newQuota);
+  const response = await fetch(url, config);
+  if (response.status !== 201) {
+    throw new Error(response.statusText);
+  }
+}
+
 export {
   serverInfo,
   listCollabs,
@@ -404,5 +448,8 @@ export {
   createProject,
   deleteProject,
   queryProjects,
+  queryResourceRequests,
+  updateResourceRequest,
+  addQuota,
   resetCache,
 };

--- a/src/globals-prod.ts
+++ b/src/globals-prod.ts
@@ -3,6 +3,38 @@ export const authServer = "https://iam.ebrains.eu";
 export const authClientId = "neuromorphic-remote-access";
 export const driveServer = "https://corsproxy.apps.ebrains.eu/https://drive.ebrains.eu";
 
+// Configuration for the admin section.
+export const authScopes = "team email profile roles";
+
+// EBRAINS userinfo endpoint, fetched through the CORS proxy so it can be read from the
+// browser. Used to determine whether the logged-in user is a platform administrator.
+export const corsProxy = "https://corsproxy.apps.ebrains.eu/";
+export const userInfoUrl =
+  corsProxy + `${authServer}/auth/realms/hbp/protocol/openid-connect/userinfo`;
+
+// Roles that grant access to the admin section.
+export const adminRoles = [
+  "collab-neuromorphic-platform-admin-editor",
+  "collab-neuromorphic-platform-admin-administrator",
+];
+
+// Per-platform defaults used by the admin quota form.
+export const defaultQuotaSizes: Record<string, string> = {
+  BrainScaleS: "0.1",
+  "BrainScaleS-2": "1.0",
+  SpiNNaker: "5000.0",
+  Spikey: "1.0",
+  Demo: "1.0",
+};
+
+export const platformUnits: Record<string, string> = {
+  BrainScaleS: "wafer-hours",
+  "BrainScaleS-2": "chip-hours",
+  SpiNNaker: "core-hours",
+  Spikey: "hours",
+  Demo: "hours",
+};
+
 export const hw_options = [
   "BrainScaleS",
   "SpiNNaker",

--- a/src/globals-staging.ts
+++ b/src/globals-staging.ts
@@ -3,6 +3,38 @@ export const authServer = "https://iam.ebrains.eu";
 export const authClientId = "neuromorphic-remote-access";
 export const driveServer = "https://corsproxy.apps.ebrains.eu/https://drive.ebrains.eu";
 
+// Configuration for the admin section.
+export const authScopes = "team email profile roles";
+
+// EBRAINS userinfo endpoint, fetched through the CORS proxy so it can be read from the
+// browser. Used to determine whether the logged-in user is a platform administrator.
+export const corsProxy = "https://corsproxy.apps.ebrains.eu/";
+export const userInfoUrl =
+  corsProxy + `${authServer}/auth/realms/hbp/protocol/openid-connect/userinfo`;
+
+// Roles that grant access to the admin section.
+export const adminRoles = [
+  "collab-neuromorphic-platform-admin-editor",
+  "collab-neuromorphic-platform-admin-administrator",
+];
+
+// Per-platform defaults used by the admin quota form.
+export const defaultQuotaSizes: Record<string, string> = {
+  BrainScaleS: "0.1",
+  "BrainScaleS-2": "1.0",
+  SpiNNaker: "5000.0",
+  Spikey: "1.0",
+  Demo: "1.0",
+};
+
+export const platformUnits: Record<string, string> = {
+  BrainScaleS: "wafer-hours",
+  "BrainScaleS-2": "chip-hours",
+  SpiNNaker: "core-hours",
+  Spikey: "hours",
+  Demo: "hours",
+};
+
 export const hw_options = [
   "BrainScaleS",
   "SpiNNaker",

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -7,6 +7,38 @@ export const authServer = "https://iam-int.ebrains.eu";
 export const authClientId = "neuromorphic-remote-access-dev";
 export const driveServer = "https://corsproxy.apps.ebrains.eu/https://drive-int.ebrains.eu";
 
+// Configuration for the admin section.
+export const authScopes = "team email profile roles";
+
+// EBRAINS userinfo endpoint, fetched through the CORS proxy so it can be read from the
+// browser. Used to determine whether the logged-in user is a platform administrator.
+export const corsProxy = "https://corsproxy.apps.ebrains.eu/";
+export const userInfoUrl =
+  corsProxy + `${authServer}/auth/realms/hbp/protocol/openid-connect/userinfo`;
+
+// Roles that grant access to the admin section.
+export const adminRoles = [
+  "collab-neuromorphic-platform-admin-editor",
+  "collab-neuromorphic-platform-admin-administrator",
+];
+
+// Per-platform defaults used by the admin quota form.
+export const defaultQuotaSizes: Record<string, string> = {
+  BrainScaleS: "0.1",
+  "BrainScaleS-2": "1.0",
+  SpiNNaker: "5000.0",
+  Spikey: "1.0",
+  Demo: "1.0",
+};
+
+export const platformUnits: Record<string, string> = {
+  BrainScaleS: "wafer-hours",
+  "BrainScaleS-2": "chip-hours",
+  SpiNNaker: "core-hours",
+  Spikey: "hours",
+  Demo: "hours",
+};
+
 export const hw_options = [
   "BrainScaleS",
   "SpiNNaker",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import { CssBaseline } from "@mui/material";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { green } from "@mui/material/colors";
 
-import initAuth from "./auth";
+import initAuth, { checkPermissions } from "./auth";
 import ErrorPage from "./components/general/ErrorPage";
 import { RequestedCollabContext, AuthContext, StatusContext } from "./context";
 
@@ -17,6 +17,7 @@ import JobDetailRoute, { getLoader as jobLoader, actionOnJob } from "./routes/jo
 import { JobCreationRoute, JobEditAndResubmitRoute, submitJob } from "./routes/job-creation";
 import ProjectListRoute, { getLoader as projectListLoader } from "./routes/projects";
 import { updateProject } from "./routes/project-detail";
+import AdminRoute from "./routes/admin";
 import type { Auth } from "./types";
 
 // Define routes
@@ -61,6 +62,11 @@ function getRouter(keycloak: Auth) {
       loader: projectListLoader(keycloak),
       action: updateProject(keycloak),
     },
+    {
+      path: "/admin",
+      element: <AdminRoute />,
+      errorElement: <ErrorPage />,
+    },
   ]);
 }
 
@@ -96,6 +102,10 @@ async function renderApp(auth: Auth) {
   const about = await serverInfo();
   console.log(about);
   const status = about.status;
+
+  // Determine whether the user is a platform administrator before first render, so the
+  // admin section and its toolbar link can be gated on `auth.isAdmin`.
+  await checkPermissions(auth).catch((err) => console.error(err));
 
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,0 +1,37 @@
+// TODO: bring this route in line with the rest of the app's data flow. Every other route
+// reads through a `getLoader(auth)` closure with defer/Await, and `projects` routes its
+// mutations through a router `action` + `useFetcher` (which auto-revalidates the loader).
+// This route instead self-fetches in ResourceRequestTable's useEffect and reloads
+// imperatively on dialog close. Left as a follow-up.
+
+import { useContext } from "react";
+
+import { Container, Typography } from "@mui/material";
+
+import Toolbar from "../components/general/Toolbar";
+import ResourceRequestTable from "../components/admin/ResourceRequestTable";
+import { AuthContext } from "../context";
+
+function AdminRoute() {
+  const auth = useContext(AuthContext);
+
+  return (
+    <div>
+      <Toolbar page="admin" />
+      <main>
+        <Container maxWidth="xl">
+          <Typography variant="h2" sx={{ my: 2 }}>
+            EBRAINS Neuromorphic Platform Admin
+          </Typography>
+          {auth?.isAdmin ? (
+            <ResourceRequestTable auth={auth} />
+          ) : (
+            <Typography>This section is for administrators only.</Typography>
+          )}
+        </Container>
+      </main>
+    </div>
+  );
+}
+
+export default AdminRoute;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,24 @@ export interface Project {
   quotas: Quota[];
 }
 
+// A new quota to be added to an existing project (POST .../quotas/), used by the admin
+// section.
+export interface NewQuota {
+  limit: number;
+  platform: string;
+  units: string;
+}
+
+// Fields sent when updating a project's status/description from the admin section
+// (PUT .../{resource_uri}).
+export interface ProjectUpdate {
+  title: string;
+  status: string;
+  abstract: string;
+  owner: string;
+  description?: string;
+}
+
 export interface Comment {
   id: number;
   job_id: number;


### PR DESCRIPTION
These changes incorporate the standalone admin app into the job-manager as a new top-level /admin route, reusing the existing types, datastore, auth flow, theme, and Toolbar rather than duplicating them.

The code was copied from commit 496bbf4099c70c264f02d30d04e6bd6306788a04 of https://gitlab.ebrains.eu/neuromorphic/neuromorphic-admin-app and then adapted as necessary, making use of Claude Opus 4.8.

Implementation choices worth noting:

- Reuse the existing Project/Quota types for the admin "resource requests"; only the admin-specific NewQuota and ProjectUpdate bodies were added.
- Add checkPermissions() to auth.ts and run it once at startup so auth.isAdmin gates both the route and a conditional Toolbar link;
- Admin datastore calls use as_admin=true and bypass the per-collab cache (cross-collab queries).
- The /admin route currently self-fetches in the component instead of using a router loader/action; updating this to match the rest of the app is left as a to-do item.